### PR TITLE
simplify verify settings

### DIFF
--- a/test/IdentityStream.HttpMessageSigning.Tests/ModuleInitializer.cs
+++ b/test/IdentityStream.HttpMessageSigning.Tests/ModuleInitializer.cs
@@ -1,0 +1,14 @@
+﻿using System.IO;
+using System.Runtime.CompilerServices;
+using VerifyTests;
+
+namespace IdentityStream.HttpMessageSigning.Tests
+{
+    public static class ModuleInitializer {
+        [ModuleInitializer]
+        public static void Initialize() {
+            var directory = Path.Combine(AttributeReader.GetProjectDirectory(), "Snapshots");
+            VerifierSettings.DerivePathInfo((_, _, type, method) => new(directory, type.Name, method.Name));
+        }
+    }
+}

--- a/test/IdentityStream.HttpMessageSigning.Tests/SignatureHeaderComposerTests.cs
+++ b/test/IdentityStream.HttpMessageSigning.Tests/SignatureHeaderComposerTests.cs
@@ -13,13 +13,6 @@ namespace IdentityStream.HttpMessageSigning.Tests {
     public class SignerTests {
         private const string KeyId = "d4db0d";
 
-        public SignerTests() {
-            Settings = new VerifySettings();
-            Settings.UseDirectory("Snapshots");
-        }
-
-        private VerifySettings Settings { get; }
-
         [Fact]
         public async Task DefaultConfiguration_ProducesCorrectSignatureHeader() {
             var message = new TestHttpMessage(HttpMethod.Post, new Uri("https://identitystream.com/hello"));
@@ -80,9 +73,8 @@ namespace IdentityStream.HttpMessageSigning.Tests {
                 config.AddRecommendedHeaders = false;
             });
 
-            Settings.UseParameters(digestAlgorithm);
-
-            await Verify(message.Headers[HeaderNames.Digest].Single());
+            await Verify(message.Headers[HeaderNames.Digest].Single())
+                .UseParameters(digestAlgorithm);
         }
 
         public static IEnumerable<object[]> HashAlgorigthms {
@@ -123,7 +115,7 @@ namespace IdentityStream.HttpMessageSigning.Tests {
             throw new InvalidOperationException("Could not find Signature header on request.");
         }
 
-        private Task Verify(string value) => Verifier.Verify(value, Settings);
+        private SettingsTask Verify(string value) => Verifier.Verify(value);
 
         private static Task SignAsync(IHttpMessage message, Action<HttpMessageSigningConfiguration>? configure = null) {
             var signatureAlgorithm = new TestSignatureAlgorithm(HashAlgorithmName.SHA512);


### PR DESCRIPTION
 * use a module init to make verify settings global
 * removes need for settings instance
 * moved useparams to use the fluent api