### PR TITLE
Make HttpMessage.SetHeader replace any existing header value

### DIFF
--- a/src/IdentityStream.HttpMessageSigning/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/IdentityStream.HttpMessageSigning/Extensions/HttpRequestMessageExtensions.cs
@@ -29,8 +29,15 @@ namespace System.Net.Http {
 
             private HttpRequestMessage Request { get; }
 
-            public void SetHeader(string name, string value) =>
+            public void SetHeader(string name, string value)
+            {
+                if (Request.Headers.Contains(name))
+                {
+                    Request.Headers.Remove(name);
+                }
+                
                 Request.Headers.TryAddWithoutValidation(name, value);
+            }
 
             public bool TryGetHeaderValues(string name, [NotNullWhen(true)] out IEnumerable<string>? values) =>
                 Request.Headers.TryGetValues(name, out values);


### PR DESCRIPTION
Fixes #12 

Ensure the "Signature" value is not added multiple times when a retry happens